### PR TITLE
Allow rendering within a lambda

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -532,7 +532,14 @@ The syntax grammar is:
     (funcall (car (indent context)) nil)))
 
 (defmethod call-lambda (lambda text &optional context)
-  (let* ((value (format nil "~a" (funcall lambda text)))
+  (let* ((value (format nil "~a" 
+                        ;; Pass in a context-sensitive renderer function if the function
+                        ;; can handle it.
+                        (handler-case (funcall lambda text 
+                                               (lambda (tmpl)
+                                                 (mustache-render-to-string tmpl context)))
+                          ((or program-error simple-program-error) ()
+                            (funcall lambda text)))))
          (fun (mustache-compile value))
          (output (with-output-to-string (*mustache-output*)
                    (funcall fun context))))

--- a/t/test-spec.lisp
+++ b/t/test-spec.lisp
@@ -2,7 +2,7 @@
 (in-package :mustache-test)
 
 (deftest spec
- (plan 122)
+ (plan 124)
  (is
   (mustache-render-to-string "12345 {{! Comment Block! }} 67890"
    (mustache-context :data 'nil :partials 'nil))
@@ -1023,6 +1023,28 @@ End.
   "<yes>"
   (format nil "~A :: ~A" "Section"
           "Lambdas used for sections should receive the raw section string."))
+ ;;
+ (is
+  (mustache-render-to-string "{{#list}}{{#lambda}}{{x}}{{/lambda}} {{/list}}"
+   (mustache-context :data
+    `((:list . #(((:x . "1")) ((:x . "2"))))
+      (:lambda . ,(lambda (text) (format nil "Call~A" text))))
+    :partials 'nil))
+  "Call1 Call2 "
+  (format nil "~A :: ~A" "Nested Section - Multiple calls"
+          "Lambdas used within sections should receive the raw section string."))
+ (is
+  (mustache-render-to-string "{{#list}}{{#lambda}}{{x}}{{/lambda}} {{/list}}"
+   (mustache-context
+     :data
+     `((:parent . "Called")
+       (:list . #(((:x . "a")) ((:x . "b"))))
+       (:lambda . ,(lambda (text render) (format nil "{{> ~A-partial}}" (funcall render text)))))
+    :partials '((:a-partial . "{{parent}}A") (:b-partial . "{{parent}}B"))))
+  "CalledA CalledB "
+  (format nil "~A :: ~A" "Nested Section - Calls with renderer function"
+          "Lambdas can render text context sensitively."))
+ ;;
  (is
   (mustache-render-to-string "<{{lambda}}{{{lambda}}}"
    (mustache-context :data


### PR DESCRIPTION
Hello kanru,

I've added the ability to (context sensitively) render text within a lambda, as shown in the example documentation at http://mustache.github.com/mustache.5.html.  I wrote the code so it can also still handle lambdas that do not need the render function.  If you think this will be useful for others, please integrate it into your master code so they can access it through Quicklisp.

With this change, the context lambdas can use either one parameter or two, as shown below.

``` lisp
;; original supported lambda example
(lambda (text)
  (format nil "Call ~A" text))

;; additional supported lambda example, for instance for use in a loop.
(lambda (text render)
  (format nil "{{> ~A-partial}}" (funcall render text)))
```

Thanks,
Jonathan

SHA: 1ccf564df3bb1ba3bd8b684b2ab6541ce48f1c8c
