### PR TITLE
Escape unprintables

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -516,8 +516,7 @@ variable before calling mustache-rendering and friends. Default is
 
 (defmethod print-data ((data symbol) escapep &optional context)
   (declare (ignore context))
-  (write-string (if escapep (escape (string data)) data) *mustache-output*))
-
+  (print-data (string data) escapep))
 
 (defmethod print-data ((data function) escapep &optional context)
   (let* ((value (format nil "~a" (funcall data)))

--- a/t/test-api.lisp
+++ b/t/test-api.lisp
@@ -30,6 +30,9 @@
 
 (in-package :mustache-test)
 
+(defclass unreadable-class ()
+  ())
+
 (deftest api
     (progn
       (is-type (mustache-type) 'string
@@ -94,11 +97,14 @@
           "&lt;&gt;&amp;&quot;&apos;"
           "escape char")
 
-      (is (mustache-render-to-string "{{unknown-type}}"
-                                     (mustache-context
-                                      :data `((unknown-type . ,(make-instance 'class)))))
-          "#&lt;CLASS NIL&gt;"
-          "escape non printable types")
+
+      (let ((unreadable-instance (make-instance 'unreadable-class)))
+        (is (mustache-render-to-string "!!{{unknown-type}}!!"
+                                      (mustache-context
+                                       :data `((unknown-type . ,unreadable-instance))))
+            (format nil "!!~a!!" (mustache::escape (princ-to-string unreadable-instance)))
+            "escape non printable types"))
+
 
       (is (mustache-render-to-string "{{symbol}}"
                                      (mustache-context


### PR DESCRIPTION
Hey, 

i noticed that some objects are rendered unescaped if the objects are unprintable. Printing Objects resulted in an unescaped output: `#<CLASS #x3020027F091D>`, but the output should better be `#&lt;CLASS #x3020027F091D&gt;`

I also added a method for printing symbols. The leads to an uppercased representation of the symbol.

This patch adds also two simple tests for the above cases. 

Greetings 
