### PR TITLE
support sections bound to strings

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -577,6 +577,8 @@ variable before calling mustache-rendering and friends. Default is
                (let ((*default-open-delimiter* (open-delimiter token))
                      (*default-close-delimiter* (close-delimiter token)))
                  (call-lambda ctx (subseq template (start token) (end token)) context)))
+              (string
+               (render context template))
               (sequence
                (map nil (lambda (ctx)
                           (render (make-context ctx context) template))


### PR DESCRIPTION
See https://github.com/kanru/cl-mustache/issues/10 and
https://gist.github.com/zickzackv/8247170

Context:

``` lisp
((a . "value"))
```

Template:
`{{#a}}{{a}}{{/a}}`

Output:

```
value
```
