### PR TITLE
Use synonym streams for *real-standard-output* and *output-stream*

### DIFF
--- a/compat-api-v1.lisp
+++ b/compat-api-v1.lisp
@@ -26,7 +26,7 @@
 
 (in-package :mustache)
 
-(defvar *mustache-output* *output-stream*
+(defvar *mustache-output* (make-synonym-stream '*output-stream*)
   "Deprecated in favor of MUSTACHE:*OUTPUT* since version 0.10.0")
 
 (define-condition deprecation-warning (style-warning)

--- a/mustache.lisp
+++ b/mustache.lisp
@@ -571,8 +571,8 @@ The syntax grammar is:
               :do (write-string (escape-char (char string pos)) datum)
             :while pos))))
 
-(defvar *real-standard-output* *standard-output*)
-(defvar *output-stream* *standard-output*
+(defvar *real-standard-output* (make-synonym-stream 'cl:*standard-output*))
+(defvar *output-stream* (make-synonym-stream 'cl:*standard-output*)
   "The default output stream for mustache rendering. Bind this
 variable before calling mustache-rendering and friends. Default is
 *standard-output*.")


### PR DESCRIPTION
Previous code had a bug that manifested itself when cl:*standard-output* had been modified during when the code was loaded.

To test the bug do run 

```lisp
(ql:quickload :cl-mustache :slient t)
```

## Output
```
CL-USER> mustache:*mustache-output*
#<SB-SYS:FD-STREAM for "socket 127.0.0.1:58061, peer: 127.0.0.1:60612" {1003CB0183}>
CL-USER> mustache:*output-stream*
#<SB-SYS:FD-STREAM for "socket 127.0.0.1:58061, peer: 127.0.0.1:60612" {1003CB0183}>
CL-USER> mustache::*real-standard-output*
#<SB-SYS:FD-STREAM for "socket 127.0.0.1:58061, peer: 127.0.0.1:60612" {1003CB0183}>
```

Btw I think shredding api compatibility and cleaning up the code wouldn't be a bad idea either.

The bug was reported on IRC: http://log.irc.tymoon.eu/freenode/lisp?around=2015-08-24T08:34:48&types=mnaot#1440405288 See comments from Xach below.