### PR TITLE
Fix documentation string of *MUSTACHE-OUTPUT*

### DIFF
--- a/compat-api-v1.lisp
+++ b/compat-api-v1.lisp
@@ -27,7 +27,7 @@
 (in-package :mustache)
 
 (defvar *mustache-output* (make-synonym-stream '*output-stream*)
-  "Deprecated in favor of MUSTACHE:*OUTPUT* since version 0.10.0")
+  "Deprecated in favor of MUSTACHE:*OUTPUT-STREAM* since version 0.10.0")
 
 (define-condition deprecation-warning (style-warning)
   ((name :initarg :name :reader deprecated-name)


### PR DESCRIPTION
_MUSTACHE-OUTPUT_ was deprecation in favor of _OUTPUT-STREAM_ not _OUTPUT_
