### PR TITLE
Allow escaping bypass

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -551,9 +551,9 @@ The syntax grammar is:
 
 ;;; Rendering Utils
 
-(defun escape (string)
-  "HTML escape STRING."
-  (declare (type string string))
+(defvar *escape-tokens* t)
+
+(defun %escape (string)
   (flet ((needs-escape-p (char)
            (member char '(#\< #\> #\& #\\ #\" #\')))
          (escape-char (char)
@@ -565,11 +565,18 @@ The syntax grammar is:
              (t (format nil "&#~d;" (char-code char))))))
     (with-output-to-string (datum)
       (loop :for start := 0 :then (1+ pos)
-            :for pos := (position-if #'needs-escape-p string :start start)
-            :do (write-string string datum :start start :end pos)
-            :when pos
-              :do (write-string (escape-char (char string pos)) datum)
-            :while pos))))
+         :for pos := (position-if #'needs-escape-p string :start start)
+         :do (write-string string datum :start start :end pos)
+         :when pos
+         :do (write-string (escape-char (char string pos)) datum)
+         :while pos))))
+
+(defun escape (string)
+  "HTML escape STRING when *escape-tokens* is t."
+  (declare (type string string))
+  (if *escape-tokens*
+      (%escape string)
+      string))
 
 (defvar *real-standard-output* (make-synonym-stream 'cl:*standard-output*))
 (defvar *output-stream* (make-synonym-stream 'cl:*standard-output*)

--- a/packages.lisp
+++ b/packages.lisp
@@ -24,7 +24,7 @@
 
 ;;;; Commentary:
 
-;;; 
+;;;
 
 ;;;; Code:
 
@@ -37,6 +37,7 @@
            ;; new
            #:*output-stream*
            #:*context*
+           #:*escape-tokens*
            #:version
            #:make-context
            #:compile-template


### PR DESCRIPTION
`*escape-tokens*` special variable allows to bypass escaping and leave tokens as they are. Useful when using `cl-mustache` to render into formats other than `html`/`xml` (e.g. markdown).