### PR TITLE
Remove use of obsolete *mustache-output* from mustache.lisp.

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -577,10 +577,7 @@ The syntax grammar is:
 variable before calling mustache-rendering and friends. Default is
 *standard-output*.")
 
-(defun %output ()
-  (if (eq *mustache-output* *real-standard-output*)
-      *output-stream*
-      *mustache-output*))
+(defun %output () *output-stream*)
 
 (defgeneric print-data (data escapep context))
 


### PR DESCRIPTION
#27 

I'm not sure if this is the correct approach, it might break backwards compatibility with versions before 0.10.