### PR TITLE
Fix for rendering non-objects in a list

### DIFF
--- a/mustache.lisp
+++ b/mustache.lisp
@@ -489,6 +489,10 @@ The syntax grammar is:
 (defgeneric context-get (key context)
   (:documentation "Get data from CONTEXT by KEY."))
 
+(defmethod context-get ((key string) context)
+  (declare (ignore key))
+  (values))
+
 (defmethod context-get ((key string) (context null))
   (declare (ignore key))
   (values))
@@ -496,7 +500,7 @@ The syntax grammar is:
 (defmethod context-get ((key string) (context hash-table))
   (gethash (string-upcase key) context))
 
-(defmethod context-get ((key string) context)
+(defmethod context-get ((key string) (context context))
   (multiple-value-bind (data find)
       (context-get key (data context))
     (if find

--- a/t/test-api.lisp
+++ b/t/test-api.lisp
@@ -36,7 +36,7 @@
 (defclass unreadable-class ()
   ())
 
-(plan 14)
+(plan 15)
 
 (is-type (mustache:version) 'string
          "(mustache:version) is a version string")
@@ -111,6 +111,12 @@
                       '((symbol . symbol)))
     "SYMBOL"
     "print symbols")
+
+(is (mustache:render* "{{#list}}{{var}}{{/list}}"
+                      '((:var . "foo")
+                        (:list . (1 2 3))))
+    "foofoofoo"
+    "look in parent context for key")
 
 (finalize)
 


### PR DESCRIPTION
Fixes  #29
Specialize the existing `context-get` on `context` since it depends on data & next methods
Make a specialization for any t to just ignore it (so that parent context will take over)

I wasn't sure if I should remove the specialization on null or not since it's now unnecessary, but maybe it's more clear this way?